### PR TITLE
Dev/update tankings via datastreams

### DIFF
--- a/app/src/main/java/com/example/fuelconsumption2/MainActivity.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/MainActivity.kt
@@ -28,7 +28,6 @@ import com.example.fuelconsumption2.data.typeConverters.FuelTypeConverter
 import com.example.fuelconsumption2.enums.FuelType
 import kotlinx.coroutines.launch
 import java.time.Instant
-import java.util.Locale
 
 class MainActivity : AppCompatActivity() {
 
@@ -66,7 +65,7 @@ class MainActivity : AppCompatActivity() {
             insets
         }
 
-        tankingsSummaryViewModel.initiateTankingsSummaryState()
+        tankingsSummaryViewModel.initializeState()
 
         val tankingsRecyclerAdapter = TankingsRecyclerAdapter()
         findViewById<RecyclerView?>(R.id.tankingsView).apply {

--- a/app/src/main/java/com/example/fuelconsumption2/MainActivity.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/MainActivity.kt
@@ -74,8 +74,11 @@ class MainActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            tankingsSummaryViewModel.state.collect { state ->
-                tankingsRecyclerAdapter.updateTankings(state.visibleTankings)
+//            tankingsSummaryViewModel.state.collect { state ->
+//                tankingsRecyclerAdapter.updateTankings(state.visibleTankings)
+//            }
+            tankingsSummaryViewModel.currentTankings.collect { currentTankings ->
+                tankingsRecyclerAdapter.updateTankings(currentTankings)
             }
         }
 
@@ -200,7 +203,7 @@ class MainActivity : AppCompatActivity() {
                                             "Tanking added successfully",
                                             Toast.LENGTH_SHORT
                                         ).show()
-                                        tankingsSummaryViewModel.refreshVisibleTankings()
+                                        //tankingsSummaryViewModel.refreshVisibleTankings()
                                     }
                                 }
                             }

--- a/app/src/main/java/com/example/fuelconsumption2/MainActivity.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/MainActivity.kt
@@ -1,10 +1,17 @@
 package com.example.fuelconsumption2
 
 import android.os.Bundle
-import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import android.widget.Button
+import android.widget.EditText
+import android.widget.Spinner
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -15,7 +22,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.room.Room
 import com.example.fuelconsumption2.data.AppDatabase
+import com.example.fuelconsumption2.data.entities.Tanking
+import com.example.fuelconsumption2.data.entities.Vehicle
+import com.example.fuelconsumption2.data.typeConverters.FuelTypeConverter
+import com.example.fuelconsumption2.enums.FuelType
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.util.Locale
 
 class MainActivity : AppCompatActivity() {
 
@@ -79,8 +92,121 @@ class MainActivity : AppCompatActivity() {
                     is TankingEvent.HideAddVehicleDialog -> TODO()
 
                     is TankingEvent.ShowAddTankingDialog -> {
-                        //tankingsSummaryViewModel.state.isAddingTanking = true via VM fun using _state
-                        tankingsSummaryViewModel.showAddTankingDialog(this@MainActivity)
+                        val addTankingDialogView = LayoutInflater.from(this@MainActivity).inflate(R.layout.add_tanking, null)
+                        val addTankingDialog = AlertDialog.Builder(this@MainActivity)
+                            .setView(addTankingDialogView)
+                            .setTitle("Add tanking")
+                            .create()
+
+                        val fuelPick: Spinner = addTankingDialogView.findViewById(R.id.addTankingFuelType)
+                        val fuelTypes = mutableListOf("No fuel selected").apply {
+                            addAll(FuelType.entries.toTypedArray().map {
+                                it.name
+                            })
+                        }
+                        fuelPick.adapter = ArrayAdapter(
+                            this@MainActivity,
+                            android.R.layout.simple_spinner_item,
+                            fuelTypes
+                        ).apply {
+                            setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                        }
+                        fuelPick.setSelection(0) //Default to "No fuel selected"
+
+                        val vehiclePick: Spinner = addTankingDialogView.findViewById(R.id.addTankingVehiclePick)
+
+                        lifecycleScope.launch {
+                            val recentVehicleId = tankingsSummaryViewModel.state.value.currentVehicle
+
+                            val vehicles = tankingsSummaryViewModel.getAllVehiclesForAddingTanking()
+
+                            val vehicleNames = mutableListOf("No vehicle selected").apply {
+                                addAll(vehicles.map { it.Name ?: ( "Vehicle " + it.VehicleId + " with null name" ) })
+                            }
+
+                            vehiclePick.adapter = ArrayAdapter(
+                                this@MainActivity,
+                                android.R.layout.simple_spinner_item,
+                                vehicleNames
+                            ).apply {
+                                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                            }
+
+                            var selectedVehicle = Vehicle()
+                            vehiclePick.onItemSelectedListener = object: AdapterView.OnItemSelectedListener {
+                                override fun onItemSelected(parent: AdapterView<*>, view: View, vehiclePosition: Int, id: Long) {
+                                    if (vehicles.isNotEmpty()) selectedVehicle = vehicles[vehiclePosition]
+                                    val fuelTypeName = selectedVehicle.DefaultFuelType?.name ?: "No fuel selected"
+                                    fuelPick.setSelection(fuelTypes.indexOf(fuelTypeName).coerceAtLeast(0))
+                                    //TODO("Unit test that shit. fuelTypes is passed hand-to-hand but the user may mess up the spinner somehow.")
+
+                                    val kilometersBefore = selectedVehicle.Kilometers?.toString() ?: "No km stored"
+                                    addTankingDialogView.findViewById<EditText>(R.id.addTankingKilometersBefore).setText(kilometersBefore)
+                                }
+                                override fun onNothingSelected(parent: AdapterView<*>) {}
+                            }
+
+                            /*
+                                `recentVehicleId` is served by `ConfigurationRepository` and
+                                `vehicles` are served by `VehicleRepository`
+                                both using absolute indexes in `db`
+                                but I'm adding a placeholder vehicle so they match 1:1+1
+                                TODO("Unit test that shit.")
+                            */
+                            vehiclePick.setSelection((recentVehicleId?.plus(1)) ?: 0)
+
+                            addTankingDialogView.findViewById<Button>(R.id.addTankingSubmit).setOnClickListener {
+                                val fuelTypeText = fuelPick.selectedItem.toString()
+                                val fuelType = if (fuelTypeText == "No fuel selected") {
+                                    Toast.makeText(this@MainActivity, "Fuel type will be null.", Toast.LENGTH_SHORT).show()
+                                    null
+                                } else {
+                                    FuelTypeConverter().toFuelType(fuelTypeText)
+                                }
+                                val kilometersBeforeText = addTankingDialogView.findViewById<EditText>(R.id.addTankingKilometersBefore).text.toString()
+                                val kilometersAfterText = addTankingDialogView.findViewById<EditText>(R.id.addTankingKilometersAfter).text.toString()
+                                val amountOfFuelText = addTankingDialogView.findViewById<EditText>(R.id.addTankingAmount).text.toString()
+                                val priceText = addTankingDialogView.findViewById<EditText>(R.id.addTankingPrice).text.toString()
+
+                                if (listOf(kilometersBeforeText, kilometersAfterText, amountOfFuelText, priceText, fuelTypeText).any { it.isBlank() }) {
+                                    Toast.makeText(this@MainActivity, "Please fill in all fields", Toast.LENGTH_SHORT).show()
+                                    return@setOnClickListener
+                                }
+
+                                val newTanking = Tanking(
+                                    TankingId = 0, // Room will auto-re-generate this ID
+                                    VehicleId = selectedVehicle.VehicleId,
+                                    KilometersBefore = kilometersBeforeText.toIntOrNull() ?: 0,
+                                    KilometersAfter = kilometersAfterText.toIntOrNull() ?: 0,
+                                    FuelAmount = amountOfFuelText.toFloatOrNull() ?: 0f,
+                                    Timestamp = Instant.now().toEpochMilli(),
+                                    Price = priceText.toFloatOrNull() ?: 0f,
+                                    FuelType = fuelType,
+                                    Cost = (priceText.toFloatOrNull() ?: 0f) * (amountOfFuelText.toFloatOrNull() ?: 0f)
+                                )
+
+                                lifecycleScope.launch {
+                                    try {
+                                        tankingsSummaryViewModel.insertTanking(newTanking)
+                                    } catch (e: Exception) {
+                                        Toast.makeText(
+                                            this@MainActivity,
+                                            "Error adding Tanking: ${e.message}",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    } finally {
+                                        addTankingDialog.dismiss()
+                                        Toast.makeText(
+                                            this@MainActivity,
+                                            "Tanking added successfully",
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                        tankingsSummaryViewModel.refreshVisibleTankings()
+                                    }
+                                }
+                            }
+                        }
+                        addTankingDialog.show()
                     }
 
                     is TankingEvent.HideAddTankingDialog -> TODO()

--- a/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryState.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryState.kt
@@ -10,7 +10,6 @@ import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
 data class TankingsSummaryState(
-    val visibleTankings: List<Tanking> = emptyList<Tanking>(),
     val currentDate: SteroidDate? = null,
     val averageConsumption: Float? = 0.0f,
     val averageCost: Float? = 0.0f,

--- a/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.fuelconsumption2
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.fuelconsumption2.data.AppDatabase
@@ -50,9 +51,7 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
 
             val recentVehicleId = configurationRepository.getRecentVehicleId()
 
-            tankingRepository.getAllTankingsInBetweenByVehicleId(recentVehicleId, historyStart, historyEnd).collect { data ->
-                _currentTankings.value = data
-            }
+            _currentTankings.value = tankingRepository.getAllTankingsInBetweenByVehicleId(recentVehicleId, historyStart, historyEnd)
 
             val totalFuel = _currentTankings.value.fold(0f) { acc, tanking -> acc + (tanking.FuelAmount ?: 0f) }
             val kilometersBefore = _currentTankings.value.firstOrNull()?.KilometersBefore ?: 0
@@ -102,6 +101,9 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
         }
     }
 
+    suspend fun updateCurrentTankings(start: Long?, end: Long?) {
+            _currentTankings.value = tankingRepository.getAllTankingsInBetweenByVehicleId(_state.value.currentVehicle, start, end)
+    }
 //    suspend fun refreshVisibleTankings() {
 //        val currentTankings = tankingRepository.getAllTankingsInBetweenByVehicleId(_state.value.currentVehicle, _state.value.historyFilterStart, _state.value.historyFilterEnd)
 //        _state.update {

--- a/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
@@ -74,12 +74,6 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
     }
 
     //TANKINGS
-    suspend fun insertTankings(vararg newTanking: Tanking) {
-        viewModelScope.launch {
-            tankingRepository.insertTankings(*newTanking)
-        }
-    }
-
     suspend fun insertTanking(tanking: Tanking) {
         viewModelScope.launch {
             tankingRepository.insertTankings(tanking)
@@ -107,15 +101,7 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
         }
     }
 
-    fun getAllTankings(): Flow<List<Tanking>> {
-        return tankingRepository.getAllTankings()
-    }
-
     //VEHICLES
-    fun getVehicleById(vehicleId: Int): Flow<Vehicle> {
-        return vehicleRepository.getVehicleById(vehicleId)
-    }
-
     suspend fun getAllVehiclesForAddingTanking(): List<Vehicle> {
         return vehicleRepository.getAllVehiclesForAddingTanking()
     }

--- a/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
@@ -34,7 +34,7 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
     private val _events = MutableSharedFlow<TankingEvent>()
     val events: SharedFlow<TankingEvent> = _events.asSharedFlow()
 
-    private val _currentTankings = MutableStateFlow<List<Tanking>>(emptyList())
+    private var _currentTankings = MutableStateFlow<List<Tanking>>(emptyList())
     val currentTankings: StateFlow<List<Tanking>> get() = _currentTankings
 
     fun initializeState() {
@@ -50,7 +50,9 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
 
             val recentVehicleId = configurationRepository.getRecentVehicleId()
 
-            _currentTankings.value = tankingRepository.getAllTankingsInBetweenByVehicleId(recentVehicleId, historyStart, historyEnd)
+            tankingRepository.getAllTankingsInBetweenByVehicleId(recentVehicleId, historyStart, historyEnd).collect { data ->
+                _currentTankings.value = data
+            }
 
             val totalFuel = _currentTankings.value.fold(0f) { acc, tanking -> acc + (tanking.FuelAmount ?: 0f) }
             val kilometersBefore = _currentTankings.value.firstOrNull()?.KilometersBefore ?: 0

--- a/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/TankingsSummaryViewModel.kt
@@ -1,15 +1,5 @@
 package com.example.fuelconsumption2
 
-import android.content.Context
-import android.view.LayoutInflater
-import android.view.View
-import android.widget.AdapterView
-import android.widget.ArrayAdapter
-import android.widget.Button
-import android.widget.EditText
-import android.widget.Spinner
-import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.fuelconsumption2.data.AppDatabase
@@ -19,8 +9,6 @@ import com.example.fuelconsumption2.data.entities.Vehicle
 import com.example.fuelconsumption2.data.repository.ConfigurationRepository
 import com.example.fuelconsumption2.data.repository.TankingRepository
 import com.example.fuelconsumption2.data.repository.VehicleRepository
-import com.example.fuelconsumption2.data.typeConverters.FuelTypeConverter
-import com.example.fuelconsumption2.enums.FuelType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,8 +20,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Instant
-import java.util.Locale
-import kotlin.math.tan
 
 class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
     private val tankingRepository = TankingRepository(db.tankingDao())
@@ -46,20 +32,10 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
     private val _events = MutableSharedFlow<TankingEvent>()
     val events: SharedFlow<TankingEvent> = _events.asSharedFlow()
 
-    fun initiateTankingsSummaryState() {
+    fun initializeState() {
         val currentTimestamp = Instant.now()
-
-        val historyStartFromStateOrInitial = if (_state.value.historyFilterEnd != null) {
-            _state.value.historyFilterEnd
-        } else {
-            SteroidDate.oneYearBefore(currentTimestamp).getTimestamp()
-        }
-
-        val historyEndFromStateOrInitial = if (_state.value.historyFilterStart != null) {
-            _state.value.historyFilterStart
-        } else {
-            SteroidDate(currentTimestamp.toEpochMilli()).getTimestamp()
-        }
+        val historyStart = _state.value.historyFilterEnd ?: SteroidDate.oneYearBefore(currentTimestamp).getTimestamp()
+        val historyEnd = _state.value.historyFilterStart ?: SteroidDate(currentTimestamp.toEpochMilli()).getTimestamp()
 
         viewModelScope.launch {
             if(configurationRepository.isConfigurationEmpty()) {
@@ -67,32 +43,15 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
                 configurationRepository.insertConfiguration(defaultConfiguration)
             }
 
-            val recentVehicleId: Int? = configurationRepository.getRecentVehicleId()
-
-            val visibleTankingsFetched = tankingRepository.getAllTankingsInBetweenByVehicleId(
-                recentVehicleId,
-                historyStartFromStateOrInitial,
-                historyEndFromStateOrInitial
-            )
-
-            val totalFuel = visibleTankingsFetched.fold(0f) { acc, tanking ->
-                acc + (tanking.FuelAmount ?: 0f)
-            }
-
+            val recentVehicleId = configurationRepository.getRecentVehicleId()
+            val visibleTankingsFetched = tankingRepository.getAllTankingsInBetweenByVehicleId(recentVehicleId, historyStart, historyEnd)
+            val totalFuel = visibleTankingsFetched.fold(0f) { acc, tanking -> acc + (tanking.FuelAmount ?: 0f) }
             val kilometersBefore = visibleTankingsFetched.firstOrNull()?.KilometersBefore ?: 0
             val kilometersAfter = visibleTankingsFetched.lastOrNull()?.KilometersAfter ?: 0
             val totalKm = kilometersBefore - kilometersAfter
-
-            val totalCost = visibleTankingsFetched.fold(0f) { acc, tanking ->
-                acc + (tanking.Cost ?: 0f)
-            }
-            val averageCost = totalCost / totalKm * 100
-
-            val averageConsumption = if (totalKm > 0) {
-                (totalFuel / totalKm) * 100
-            } else {
-                0f
-            }
+            val totalCost = visibleTankingsFetched.fold(0f) { acc, tanking -> acc + (tanking.Cost ?: 0f) }
+            val averageCost = if (totalKm > 0) totalCost / totalKm * 100 else 0f
+            val averageConsumption = if (totalKm > 0) (totalFuel / totalKm) * 100 else 0f
 
             _state.update {
                 it.copy(
@@ -101,8 +60,8 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
                     averageConsumption = averageConsumption,
                     averageCost = averageCost,
                     currentVehicle = recentVehicleId,
-                    historyFilterStart = historyStartFromStateOrInitial,
-                    historyFilterEnd = historyEndFromStateOrInitial
+                    historyFilterStart = historyStart,
+                    historyFilterEnd = historyEnd
                 )
             }
         }
@@ -112,157 +71,6 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
         viewModelScope.launch {
             _events.emit(event)
         }
-    }
-
-    //EVENTS
-    fun showAddTankingDialog(context: Context) {
-        viewModelScope.launch {
-            _state.update { currentState ->
-                currentState.copy(isAddingTanking = true)
-            }
-        }
-
-        val addTankingDialogView = LayoutInflater.from(context).inflate(R.layout.add_tanking, null)
-        val addTankingDialog = AlertDialog.Builder(context)
-            .setView(addTankingDialogView)
-            .setTitle("Input data")
-            .create()
-
-        val fuelPick: Spinner = addTankingDialogView.findViewById(R.id.addTankingFuelType)
-        val fuelTypes = mutableListOf("No fuel selected").apply {
-            addAll(FuelType.entries.toTypedArray().map {
-                it.name
-            })
-        }
-        val fuelPickAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, fuelTypes)
-        fuelPickAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        fuelPick.adapter = fuelPickAdapter
-
-        fuelPick.setSelection(0) //Default to "No fuel selected"
-
-        val vehiclePick: Spinner = addTankingDialogView.findViewById(R.id.addTankingVehiclePick)
-
-        viewModelScope.launch {
-            val recentVehicleId = getRecentVehicleId()
-
-            val vehicles = vehicleRepository.getAllVehiclesForAddingTanking()
-
-            var selectedVehicle = Vehicle(VehicleId = -1, Name = "Vehicle -1 with null name", RegistryNumber = null, Kilometers = null, DefaultFuelType = null)
-
-            val vehicleNames = mutableListOf("No vehicle selected")
-            vehicleNames.addAll(vehicles.map { it.Name ?: ( "Vehicle " + it.VehicleId + " with null name" ) })
-
-            val vehiclePickAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, vehicleNames)
-            vehiclePickAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            vehiclePick.adapter = vehiclePickAdapter
-
-            vehiclePick.onItemSelectedListener = object: AdapterView.OnItemSelectedListener {
-                override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
-                    if (vehicles.isNotEmpty()) selectedVehicle = vehicles[position]
-
-                    updateAddTankingPopupOnVehicleSelection(selectedVehicle, fuelTypes, addTankingDialogView)
-                }
-                override fun onNothingSelected(parent: AdapterView<*>) {
-                    // it will never happen because "No vehicle selected" is the hard-coded default selection
-                }
-            }
-
-            if(recentVehicleId == null) {
-                vehiclePick.setSelection(0)
-            } else {
-                /*
-                    `recentVehicleId` is served by `ConfigurationRepository` and
-                    `vehicles` are served by `VehicleRepository`
-                    both using absolute indexes in `db`
-                    but I'm adding a placeholder vehicle so they match 1:1+1
-                    TODO("Unit test that shit.")
-                */
-                vehiclePick.setSelection(recentVehicleId+1)
-            }
-
-            addTankingDialogView.findViewById<Button>(R.id.addTankingSubmit).setOnClickListener {
-                val fuelTypeText = fuelPick.selectedItem.toString()
-                val fuelType: FuelType? = if (fuelTypeText == "No fuel selected") {
-                    Toast.makeText(context, "Fuel type will be null.", Toast.LENGTH_SHORT).show()
-                    null
-                } else {
-                    FuelTypeConverter().toFuelType(fuelTypeText)
-                }
-                val kilometersBeforeText = addTankingDialogView.findViewById<EditText>(R.id.addTankingKilometersBefore).text.toString()
-                val kilometersAfterText = addTankingDialogView.findViewById<EditText>(R.id.addTankingKilometersAfter).text.toString()
-                val amountOfFuelText = addTankingDialogView.findViewById<EditText>(R.id.addTankingAmount).text.toString()
-                val priceText = addTankingDialogView.findViewById<EditText>(R.id.addTankingPrice).text.toString()
-
-                if (kilometersBeforeText.isBlank() || kilometersAfterText.isBlank() ||
-                    amountOfFuelText.isBlank() || priceText.isBlank() || fuelTypeText.isBlank()) {
-                    Toast.makeText(context, "Please fill in all fields", Toast.LENGTH_SHORT).show()
-                    return@setOnClickListener
-                }
-
-                val kilometersBefore = kilometersBeforeText.toIntOrNull() ?: 0
-                val kilometersAfter = kilometersAfterText.toIntOrNull() ?: 0
-                val amountOfFuel = amountOfFuelText.toFloatOrNull() ?: 0f
-                val price = priceText.toFloatOrNull() ?: 0f
-                val cost = String.format(Locale.US, "%.2f", (price * amountOfFuel)).toFloat()
-                val currentTimestamp = Instant.now().toEpochMilli()
-
-                val newTanking = Tanking(
-                    TankingId = 0, // Room will auto-re-generate this ID
-                    VehicleId = selectedVehicle.VehicleId,
-                    KilometersBefore = kilometersBefore,
-                    KilometersAfter = kilometersAfter,
-                    FuelAmount = amountOfFuel,
-                    Timestamp = currentTimestamp,
-                    Price = price,
-                    FuelType = fuelType,
-                    Cost = cost
-                )
-
-                viewModelScope.launch {
-                    try {
-                        tankingRepository.insertTankings(newTanking)
-                        Toast.makeText(context, "Tanking added successfully", Toast.LENGTH_SHORT).show()
-                        addTankingDialog.dismiss()
-
-                        val currentTimestampForState = Instant.now()
-                        val currentSteroidDate = SteroidDate(currentTimestampForState.toEpochMilli())
-                        val oneYearBeforeNowTimestamp = SteroidDate.oneYearBefore(currentTimestampForState).getTimestamp()
-
-                        _state.update {
-                            it.copy(
-                                currentDate = currentSteroidDate,
-                                isAddingTanking = false,
-                                currentVehicle = selectedVehicle.VehicleId,
-                                historyFilterStart = oneYearBeforeNowTimestamp,
-                                historyFilterEnd = currentTimestampForState.toEpochMilli()
-                            )
-                        }
-                    } catch (e: Exception) {
-                        Toast.makeText(context, "Error adding Tanking: ${e.message}", Toast.LENGTH_SHORT).show()
-                    } finally {
-                        val currentTankings = tankingRepository.getAllTankingsInBetweenByVehicleId(_state.value.currentVehicle, _state.value.historyFilterStart, _state.value.historyFilterEnd)
-                        _state.update {
-                            it.copy(visibleTankings = currentTankings)
-                        }
-                    }
-                }
-            }
-        }
-        addTankingDialog.show()
-    }
-
-    private fun updateAddTankingPopupOnVehicleSelection(vehicle: Vehicle, fuelTypes: MutableList<String>, context: View) {
-        val fuelTypeName = vehicle.DefaultFuelType?.name ?: "No fuel selected"
-        val position = fuelTypes.indexOf(fuelTypeName)
-        val fuelTypeSpinner = context.findViewById<Spinner>(R.id.addTankingFuelType)
-        if (position >= 0) {
-            fuelTypeSpinner.setSelection(position)
-        } else {
-            fuelTypeSpinner.setSelection(0)
-        }
-        //TODO("Unit test that shit. fuelTypes is passed hand-to-hand but the user may mess up the spinner somehow.")
-
-        context.findViewById<EditText>(R.id.addTankingKilometersBefore).setText(vehicle.Kilometers?.toString() ?: "No km stored")
     }
 
     //TANKINGS
@@ -310,10 +118,5 @@ class TankingsSummaryViewModel(private val db: AppDatabase): ViewModel() {
 
     suspend fun getAllVehiclesForAddingTanking(): List<Vehicle> {
         return vehicleRepository.getAllVehiclesForAddingTanking()
-    }
-
-    //CONFIGURATION
-    suspend fun getRecentVehicleId(): Int? {
-        return configurationRepository.getRecentVehicleId()
     }
 }

--- a/app/src/main/java/com/example/fuelconsumption2/data/dao/TankingDao.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/data/dao/TankingDao.kt
@@ -27,7 +27,7 @@ interface TankingDao {
     fun getAllFuelAmountsByVehicleId(vehicleId: Int): Flow<List<Float?>>
 
     @Query("SELECT * FROM tanking WHERE vehicle_id = :vehicleId AND timestamp BETWEEN :start AND :end")
-    fun getAllTankingsInBetweenByVehicleId(vehicleId: Int, start: Long, end: Long): Flow<List<Tanking>>
+    suspend fun getAllTankingsInBetweenByVehicleId(vehicleId: Int, start: Long, end: Long): List<Tanking>
 
 //TODO("Change it to ByCurrentVehicle - from config table")
 }

--- a/app/src/main/java/com/example/fuelconsumption2/data/dao/TankingDao.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/data/dao/TankingDao.kt
@@ -6,6 +6,8 @@ import androidx.room.Insert
 import androidx.room.Query
 import com.example.fuelconsumption2.data.entities.Tanking
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @Dao
 interface TankingDao {
@@ -25,7 +27,7 @@ interface TankingDao {
     fun getAllFuelAmountsByVehicleId(vehicleId: Int): Flow<List<Float?>>
 
     @Query("SELECT * FROM tanking WHERE vehicle_id = :vehicleId AND timestamp BETWEEN :start AND :end")
-    suspend fun getAllTankingsInBetweenByVehicleId(vehicleId: Int, start: Long, end: Long): List<Tanking>
+    fun getAllTankingsInBetweenByVehicleId(vehicleId: Int, start: Long, end: Long): Flow<List<Tanking>>
 
 //TODO("Change it to ByCurrentVehicle - from config table")
 }

--- a/app/src/main/java/com/example/fuelconsumption2/data/entities/Vehicle.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/data/entities/Vehicle.kt
@@ -6,9 +6,9 @@ import com.example.fuelconsumption2.enums.FuelType
 
 @Entity (tableName = "vehicle")
 data class Vehicle (
-    @PrimaryKey(autoGenerate = true) val VehicleId: Int,
-    @ColumnInfo(name = "name") val Name: String?,
-    @ColumnInfo(name = "registry_number") val RegistryNumber: String?,
-    @ColumnInfo(name = "kilometers") val Kilometers: Int?,
-    @ColumnInfo(name = "default_fuel_type") val DefaultFuelType: FuelType?
+    @PrimaryKey(autoGenerate = true) val VehicleId: Int = -1,
+    @ColumnInfo(name = "name") val Name: String? = "Vehicle -1 with null name",
+    @ColumnInfo(name = "registry_number") val RegistryNumber: String? = null,
+    @ColumnInfo(name = "kilometers") val Kilometers: Int? = 0,
+    @ColumnInfo(name = "default_fuel_type") val DefaultFuelType: FuelType? = null
     )

--- a/app/src/main/java/com/example/fuelconsumption2/data/repository/TankingRepository.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/data/repository/TankingRepository.kt
@@ -28,13 +28,13 @@ class TankingRepository(private val tankingDao: TankingDao) {
         return tankingDao.getAllTankings()
     }
 
-    fun getAllTankingsInBetweenByVehicleId(vehicleId: Int?, start: Long?, end: Long?): Flow<List<Tanking>> {
+    suspend fun getAllTankingsInBetweenByVehicleId(vehicleId: Int?, start: Long?, end: Long?): List<Tanking> {
         var nonNullVehicleId = -1
         if(vehicleId !== null) {
             nonNullVehicleId = vehicleId
         }
         return if (start == null || end == null) {
-            MutableStateFlow<List<Tanking>>(emptyList())
+            emptyList()
         } else {
             tankingDao.getAllTankingsInBetweenByVehicleId(
                 nonNullVehicleId,

--- a/app/src/main/java/com/example/fuelconsumption2/data/repository/TankingRepository.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/data/repository/TankingRepository.kt
@@ -5,6 +5,7 @@ import com.example.fuelconsumption2.data.dao.TankingDao
 import com.example.fuelconsumption2.data.entities.Tanking
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withContext
 

--- a/app/src/main/java/com/example/fuelconsumption2/data/repository/TankingRepository.kt
+++ b/app/src/main/java/com/example/fuelconsumption2/data/repository/TankingRepository.kt
@@ -5,6 +5,8 @@ import com.example.fuelconsumption2.data.dao.TankingDao
 import com.example.fuelconsumption2.data.entities.Tanking
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withContext
@@ -26,13 +28,13 @@ class TankingRepository(private val tankingDao: TankingDao) {
         return tankingDao.getAllTankings()
     }
 
-    suspend fun getAllTankingsInBetweenByVehicleId(vehicleId: Int?, start: Long?, end: Long?): List<Tanking> {
+    fun getAllTankingsInBetweenByVehicleId(vehicleId: Int?, start: Long?, end: Long?): Flow<List<Tanking>> {
         var nonNullVehicleId = -1
         if(vehicleId !== null) {
             nonNullVehicleId = vehicleId
         }
         return if (start == null || end == null) {
-            emptyList()
+            MutableStateFlow<List<Tanking>>(emptyList())
         } else {
             tankingDao.getAllTankingsInBetweenByVehicleId(
                 nonNullVehicleId,

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,10 +60,12 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/tankingsView"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="8dp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toTopOf="@+id/textAverageConsumptionDescription"
         app:layout_constraintEnd_toEndOf="@id/textAverageConsumption"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/buttonAddVehicle" />


### PR DESCRIPTION
The goal was achieved but not as I imagined. It seems that Flow structure like this:
Activity - Model - Repository - DAO
cannot be dependent on State in any easy way, in which filters for history are stored.

So I watch state filters and if those change (they change on tanking insertion), the currentTankings Flow gets updated manually. In contrast, what I wanted to accomplish was to trigger UI update on insertion automatically, by DAO Flow change. It is possible and easy, but with static parameters: vehicle, start, end. I wanted the DAO query to take it into account but it seems impossible, like:

```
data class TankingsSummaryState(
    val currentVehicle: Int? = null,
    val historyFilterStart: Long? = null,
    val historyFilterEnd: Long? = null
    )
```

```
@Query("SELECT * FROM tanking WHERE vehicle_id = :vehicleId AND timestamp BETWEEN :start AND :end")
 fun getAllTankingsInBetweenByVehicleId(vehicleId: Int, start: Long, end: Long): Flow<List<Tanking>>
```